### PR TITLE
Define codecov results standard

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 50%
+        threshold: 1%

--- a/main_test.go
+++ b/main_test.go
@@ -19,8 +19,8 @@ func Test_DefineFilePath_OneFileChoice(t *testing.T) {
 	}
 }
 
-func Test_DefineFilePath_ErrorNoFileFound(t *testing.T) {
-	if _, err := DefineFilePath("./tests", "toto"); filepath.ToSlash(err.Error()) != "No file found with pattern: "+filepath.ToSlash("tests/toto*.js") {
-		t.Errorf("DefineFilePath() does not return an error : " + filepath.ToSlash(err.Error()))
-	}
-}
+// func Test_DefineFilePath_ErrorNoFileFound(t *testing.T) {
+// 	if _, err := DefineFilePath("./tests", "toto"); filepath.ToSlash(err.Error()) != "No file found with pattern: "+filepath.ToSlash("tests/toto*.js") {
+// 		t.Errorf("DefineFilePath() does not return an error : " + filepath.ToSlash(err.Error()))
+// 	}
+// }

--- a/main_test.go
+++ b/main_test.go
@@ -19,8 +19,8 @@ func Test_DefineFilePath_OneFileChoice(t *testing.T) {
 	}
 }
 
-// func Test_DefineFilePath_ErrorNoFileFound(t *testing.T) {
-// 	if _, err := DefineFilePath("./tests", "toto"); filepath.ToSlash(err.Error()) != "No file found with pattern: "+filepath.ToSlash("tests/toto*.js") {
-// 		t.Errorf("DefineFilePath() does not return an error : " + filepath.ToSlash(err.Error()))
-// 	}
-// }
+func Test_DefineFilePath_ErrorNoFileFound(t *testing.T) {
+	if _, err := DefineFilePath("./tests", "toto"); filepath.ToSlash(err.Error()) != "No file found with pattern: "+filepath.ToSlash("tests/toto*.js") {
+		t.Errorf("DefineFilePath() does not return an error : " + filepath.ToSlash(err.Error()))
+	}
+}


### PR DESCRIPTION
Tells Codecov to fail a status check if 50% of the codebase is not covered with tests. However, it also allows for a 1% threshold, meaning the true minimum is 49%.